### PR TITLE
Align results paths

### DIFF
--- a/Common/Conf.sh
+++ b/Common/Conf.sh
@@ -95,10 +95,10 @@ GitMdisCommitSha=""
 #               |--Commit_xxxx
 #               `--Commit_xxxx
 #
-MainTestDirectoryPath="/media/tests"
+MainTestDirectoryPath="/media/tests/MDIS_Test"
 MdisSourcesDirectoryName="13MD05-90" 
 TestSourcesDirectoryName="mdis_test_system"
-MainTestDirectoryName="MDIS_Test"
+MainTestDirectoryName="MDIS_Functional"
 MdisResultsDirectoryName="Results"
 # optional - used for proprietary drivers
 MdisExternalDirectoryPath="/media/tests/MDIS_External_Sources"

--- a/MDIS_Compilation_Test/Conf.sh
+++ b/MDIS_Compilation_Test/Conf.sh
@@ -33,7 +33,7 @@ ERR_UNDEFINED=99        # 99 - undefined error
 MenPcPassword=""
 
 # Credentials, address, and command to download Git repository with 13MD05-90 sources
-GitMdisBranch="jpe-dev"
+GitMdisBranch="mad-dev"
 GitMdisCmd="git clone --recursive -b ${GitMdisBranch} https://github.com/MEN-Mikro-Elektronik/13MD05-90.git"
 # This is optional if specific commit have to be tested !
 # If Commit sha is not defined, then the most recent commit on branch is used. 
@@ -53,7 +53,7 @@ GitMdisCommitSha=""
 MainTestDirectoryPath="/media/tests/MDIS_Test"
 MdisSourcesDirectoryName="13MD05-90" 
 MdisSourcesDirectoryInstall="13MD05-90_Install"
-MainTestDirectoryName="MDIS_Compilation_Results"
+MainTestDirectoryName="MDIS_Compilation"
 MdisResultsDirectoryName="Results"
 LinuxKernelsDirectoryName="Linux_Kernels"
 

--- a/Target/St_Test_Configuration_x.sh
+++ b/Target/St_Test_Configuration_x.sh
@@ -105,7 +105,7 @@ if [ "${CmdResult}" -ne "${ERR_OK}" ] && [ "${CmdResult}" -ne "${ERR_DIR_EXISTS}
 fi
 cd "${OsNameKernel}" || exit "${ERR_NOEXIST}"
 
-TestSummaryDirectory="${MdisResultsDirectoryPath}/${CommitSha}/${TestConfiguration}/${Date}/${OsNameKernel}"
+TestSummaryDirectory="${MdisResultsDirectoryPath}/${TestConfiguration}/${Date}/${OsNameKernel}"
 cd "${MainTestDirectoryPath}" || exit "${ERR_NOEXIST}"
 
 if [ "${BuildMdis}" -eq "1" ]; then


### PR DESCRIPTION
Make default test results path more alike for both compilation and functional tests:

/media/tests/MDIS_Test/MDIS_Functional/Results/St_Test_Setup_X -> Funtional
/media/tests/MDIS_Test/MDIS_Compilation/Results/ -> Compilation