### PR TITLE
Use ssh config to access test setups

### DIFF
--- a/Common/Conf.sh
+++ b/Common/Conf.sh
@@ -62,15 +62,10 @@ TEST_CASES_MAP["501"]="bl51_boxpc"
 TEST_CASES_MAP["502"]="bl70_boxpc"
 TEST_CASES_MAP["700"]="dc19_panelpc"
 
-# Address of Target that will be tested
-MenPcIpAddr="11.10.10.12"
-
 # Credentials for Pc that will be tested - required by ssh connection and sudo cmds
 MenPcLogin="men"
 MenPcPassword="men"
 
-# Address of device that will be changing status of inputs in tested device 
-MenBoxPcIpAddr="11.10.10.10"
 INPUT_SWITCH_TIMEOUT=10 #seconds
 
 # Credentials, address, and command to download Git repository with Test Cases source

--- a/Host/Mdis_Test/Mdis_Test.sh
+++ b/Host/Mdis_Test/Mdis_Test.sh
@@ -392,11 +392,11 @@ function runTests {
 # MAIN start here
 create_test_cases_map
 if [ "${RUN_INSTANTLY}" == "1" ]; then
-    ssh-keygen -R "${MenPcIpAddr}"
     # Check if devices are available
-    if ! ping -c 2 "${MenPcIpAddr}"
+    if ! sshpass -p "${MenPcPassword}" ssh mdis-setup${TEST_SETUP} "echo"
     then
-        echo "${MenPcIpAddr} is not responding"
+        echo "mdis-setup${TEST_SETUP} is not responding"
+        exit
     fi
 
     cat "${MyDir}/../../Common/Conf.sh" > tmp.sh
@@ -414,11 +414,9 @@ if [ "${RUN_INSTANTLY}" == "1" ]; then
 else
     grub_set_os "0"
     for ExpectedOs in "${GrubOses[@]}"; do
-        ssh-keygen -R "${MenPcIpAddr}"
         # Check if devices are available
-        if ! ping -i 5 -c 4  "${MenPcIpAddr}"
-        then
-            echo "${MenPcIpAddr} is not responding"
+        if ! sshpass -p "${MenPcPassword}" ssh mdis-setup${TEST_SETUP} "echo"; then
+            echo "mdis-setup${TEST_SETUP} is not responding"
             break
         fi
         CurrentOs="$(grub_get_os)"
@@ -441,10 +439,9 @@ else
         fi
         if ! reboot_and_wait
         then
-            echo "${MenPcIpAddr} is not responding"
+            echo "mdis-setup${TEST_SETUP} is not responding"
             break
         fi
-        ssh-keygen -R "${MenPcIpAddr}"
 
         cat "${MyDir}/../../Common/Conf.sh" "${MyDir}"/Pc_Configure.sh > tmp.sh
         if ! run_script_on_remote_pc "${MyDir}"/tmp.sh

--- a/Host/Mdis_Test/Mdis_Test_Background.sh
+++ b/Host/Mdis_Test/Mdis_Test_Background.sh
@@ -34,7 +34,7 @@ while true; do
     FileExist=$(run_cmd_on_remote_pc "${CheckFileExistsCmd}")
     if [ "${FileExist}" = "true" ]; then
         # Check if there is connection with relay
-        if ping -c 2 "${MenBoxPcIpAddr}" > /dev/null 2>&1
+        if sshpass -p "${MenPcPassword}" ssh mdis-aux "echo"
         then
             # Read from lock file, which input should be changed
             debug_print_host "${LogPrefix} Lock file exists: change input ${LockFileData}"
@@ -53,7 +53,7 @@ while true; do
                 fi
             fi
         else
-            debug_print_host "${LogPrefix} No connection with relay: ${MenBoxPcIpAddr}"
+            debug_print_host "${LogPrefix} No connection with relay: mdis-aux"
         fi
     fi
 done

--- a/Host/Mdis_Test/Mdis_Test_Functions.sh
+++ b/Host/Mdis_Test/Mdis_Test_Functions.sh
@@ -21,7 +21,7 @@ function make_visible_in_log {
 # $1    command
 #
 function run_cmd_on_remote_pc {
-    sshpass -p "${MenPcPassword}" ssh -o StrictHostKeyChecking=no "${MenPcLogin}"@"${MenPcIpAddr}" "${1}"
+    sshpass -p "${MenPcPassword}" ssh -o StrictHostKeyChecking=no mdis-setup${TEST_SETUP} "${1}"
 }
 
 ############################################################################
@@ -31,7 +31,7 @@ function run_cmd_on_remote_pc {
 # $1    command
 #
 function run_cmd_on_remote_input_switch {
-    sshpass -p "${MenPcPassword}" ssh -o StrictHostKeyChecking=no "${MenPcLogin}"@"${MenBoxPcIpAddr}" "${1}"
+    sshpass -p "${MenPcPassword}" ssh -o StrictHostKeyChecking=no mdis-aux "${1}"
 }
 
 ############################################################################
@@ -41,7 +41,7 @@ function run_cmd_on_remote_input_switch {
 # $1    script
 #
 function run_script_on_remote_pc {
-    sshpass -p "${MenPcPassword}" ssh -o StrictHostKeyChecking=no "${MenPcLogin}"@"${MenPcIpAddr}" \
+    sshpass -p "${MenPcPassword}" ssh -o StrictHostKeyChecking=no mdis-setup${TEST_SETUP} \
     bash -s < "${1}"
 }
 
@@ -353,24 +353,23 @@ function reboot_and_wait {
         echo "Press <ENTER> to continue..."
         read -r -s
     fi
-    echo "Waiting for ${MenPcIpAddr}..."
+    echo "Waiting for mdis-setup${TEST_SETUP}..."
     if [ "${ManualBoot}" -eq 0 ]; then
         sleep 120
     fi
     while true; do
-        if ping -c 1 -W 2 "${MenPcIpAddr}"
+        if sshpass -p "${MenPcPassword}" ssh mdis-setup${TEST_SETUP} "echo"
         then
-            echo "Waiting for ${MenPcIpAddr} to fully start..."
-            sleep 60
+            echo "mdis-setup${TEST_SETUP} up and running..."
             Return=0
             break
         else
             TryCount=$((TryCount + 1))
-            if [ "${TryCount}" -ge 30 ]; then
+            if [ "${TryCount}" -ge 60 ]; then
                 Return=1
                 break
             fi
-            echo "Waiting for ${MenPcIpAddr}..."
+            echo "Waiting for mdis-setup${TEST_SETUP}..."
             sleep 10
         fi
     done
@@ -416,7 +415,7 @@ function downloadTestResults {
     fi
 
     echo "${LogPrefix} Retrieving the logs from the Target... folder date: "${Date}
-    sshpass -p "${MenPcPassword}" scp -r ${MenPcLogin}@${MenPcIpAddr}:${TargetFullPath} ${HostFullPath}
+    sshpass -p "${MenPcPassword}" scp -r mdis-setup${3}:${TargetFullPath} ${HostFullPath}
 
     if [ $? -eq 0 ]; then
         return "${ERR_OK}"

--- a/README.md
+++ b/README.md
@@ -179,15 +179,35 @@ Restart SSH service
     - sshpass
 
 
+## Network Setup
+
+MDIS test setups (targets) are accessed via ssh. These are the hosts the scripts will expect to be
+accessible via ssh:
+
+* mdis-setupX: The host for each target to be testet.
+* mdis-aux: The host for the auxiliary PC tha controls the relay switch (BL51 Box PC).
+
+An ssh config file is necessary:
+
+```
+cat ~/.ssh/config
+Host mdis-setup1
+    Hostname 192.168.1.101
+    User men
+
+Host mdis-setup2
+    Hostname 192.168.1.102
+    User men
+...
+# Relay Switching
+Host mdis-aux
+    Hostname 192.168.1.109
+    User men
+```
+
 ## Test script configuration
-Most important variables that have to be set in configuration file ```Common/Conf.sh```
 
-- MenPcIpAddr
-
-  IP address of test computer
-  
-  e.g.:
-  ```MenPcIpAddr="192.168.1.100"```
+These are some important variables that have to be set in configuration file ```Common/Conf.sh```
 
 - MenPcLogin
 
@@ -202,13 +222,6 @@ Most important variables that have to be set in configuration file ```Common/Con
   
   e.g.:
   ```MenPcPassword="men"```
-
-- MenBoxPcIpAddr (relay)
-
-  IP address of auxiliary Box PC BL51E
-  
-  e.g.:
-  ```MenBoxPcIpAddr="192.168.1.200"```
 
 - GitTestSourcesBranch
 


### PR DESCRIPTION
Instead of having just one Ip address for one particular test setup, make use of ssh config to access all test setups via hosts configuration.

Variables such as MenPcIpAddr and MenBoxPcIpAddr are no longer needed.