### PR TITLE
Pull Request to fix bug in test z125_uart

### DIFF
--- a/Target/Ip_Core_Tests/z125_uart.sh
+++ b/Target/Ip_Core_Tests/z125_uart.sh
@@ -87,9 +87,9 @@ function z125_uart_test {
         return "${CmdResult}"
     fi
 
-
-    if ! obtain_tty_number_list_from_board "${LogFile}" "${ChamTableDumpFile}" "${UartNoList}" "${LogPrefix}"
-    then
+    obtain_tty_number_list_from_board "${LogFile}" "${ChamTableDumpFile}" "${UartNoList}" "${LogPrefix}"
+    CmdResult=$?
+    if [ "${CmdResult}" -ne "${ERR_OK}" ]; then
         debug_print "${LogPrefix} obtain_tty_number_list_from_board failed, err: ${CmdResult}" "${LogFile}"
         return "${CmdResult}"
     fi


### PR DESCRIPTION
We have detected that when using the **mcb** & **mcb_pci** upstream modules loaded in the kernel, the test **z125_uart** for G215 & F215 boards in test setup 1 are passing, however, If we review the logs, the tests are actually failing for both boards.

```
[100]_z125_uart obtain_tty_number_list_from_board failed, err: 0
[100] Test_Result for Test_x_100_z125_uart_1_Test_Case: SUCCESS
....
[104]_z125_uart obtain_tty_number_list_from_board failed, err: 0
[104] Test_Result for Test_x_104_z125_uart_1_Test_Case: SUCCESS
```

This PR fixes this issue.