### PR TITLE
Pull Request for fixing the tests of M-Modules M35 and M36

### DIFF
--- a/Target/St_Functions.sh
+++ b/Target/St_Functions.sh
@@ -865,16 +865,22 @@ function m_module_x_test {
                 # *** ERROR (LINUX) #2:  No such file or directory ***
                 debug_print "${LogPrefix} RunExampleInputDisable" "${LogFile}"
                 run_as_root ${ModuleSimp} ${ModuleInstanceName} > "${MModuleName}_${MModuleBoardNr}_${ModuleSimpOutput}_output_disconnected.txt" 2>&1
-                ErrorLogCnt=$(grep "ERROR" "${MModuleName}_${MModuleBoardNr}_${ModuleSimpOutput}_output_disconnected.txt" | grep -c "No such file or directory") 
-                CmdResult="${ErrorLogCnt}"
+                CmdResult=$?
                 if [ "${CmdResult}" -ne "${ERR_OK}" ]; then
-                    debug_print "${LogPrefix} Error: ${ERR_SIMP_ERROR} :could not run ${ModuleSimp} ${ModuleInstanceName}" "${LogFile}"
+                    debug_print "${LogPrefix} [InputDisabled] Error: could not run ${ModuleSimp} ${ModuleInstanceName}" "${LogFile}"
                     MachineRun=false
                 else
-                    if [ "${MModuleName}" == "m35" ] && [ "${SubtestName}" == "blkread" ]; then
-                        MachineState="CompareResults"
+                    ErrorLogCnt=$(grep "ERROR" "${MModuleName}_${MModuleBoardNr}_${ModuleSimpOutput}_output_disconnected.txt" | grep -c "No such file or directory")
+                    CmdResult="${ErrorLogCnt}"
+                    if [ "${CmdResult}" -ne "${ERR_OK}" ]; then
+                        debug_print "${LogPrefix} Error: ${ERR_SIMP_ERROR} :could not run ${ModuleSimp} ${ModuleInstanceName}" "${LogFile}"
+                        MachineRun=false
                     else
-                        MachineState="EnableInput"
+                        if [ "${MModuleName}" == "m35" ] && [ "${SubtestName}" == "blkread" ]; then
+                            MachineState="CompareResults"
+                        else
+                            MachineState="EnableInput"
+                        fi
                     fi
                 fi
                 ;;
@@ -895,13 +901,19 @@ function m_module_x_test {
                 # *** ERROR (LINUX) #2:  No such file or directory ***
                 debug_print "${LogPrefix} RunExampleInputEnable" "${LogFile}"
                 run_as_root ${ModuleSimp} ${ModuleInstanceName} > "${MModuleName}_${MModuleBoardNr}_${ModuleSimpOutput}_output_connected.txt" 2>&1
-                ErrorLogCnt=$(grep "ERROR" "${MModuleName}_${MModuleBoardNr}_${ModuleSimpOutput}_output_connected.txt" | grep -c "No such file or directory") 
-                CmdResult="${ErrorLogCnt}"
+                CmdResult=$?
                 if [ "${CmdResult}" -ne "${ERR_OK}" ]; then
-                    debug_print "${LogPrefix} Error: ${ERR_SIMP_ERROR} :could not run ${ModuleSimp} ${ModuleInstanceName}" "${LogFile}"
-                    MachineState="DisableInput"
+                    debug_print "${LogPrefix} [InputEnabled] Error: could not run ${ModuleSimp} ${ModuleInstanceName}" "${LogFile}"
+                    MachineRun=false
                 else
-                    MachineState="CompareResults"
+                    ErrorLogCnt=$(grep "ERROR" "${MModuleName}_${MModuleBoardNr}_${ModuleSimpOutput}_output_connected.txt" | grep -c "No such file or directory")
+                    CmdResult="${ErrorLogCnt}"
+                    if [ "${CmdResult}" -ne "${ERR_OK}" ]; then
+                        debug_print "${LogPrefix} Error: ${ERR_SIMP_ERROR} :could not run ${ModuleSimp} ${ModuleInstanceName}" "${LogFile}"
+                        MachineState="DisableInput"
+                    else
+                        MachineState="CompareResults"
+                    fi
                 fi
                 ;;
             CompareResults)


### PR DESCRIPTION
During the testing of the test setup with Red Hat Linux Enterprise, we have detected that the tests for M-Modules M35 and M36, were having a weird behaviour.

In M35, the test was failing but no error was reported, and in M36, the was passing. After a further analysis, we have detected that the example binaries for M35 and M36 were not being executed because they were installed in a folder (/usr/local/bin) that was not included in the PATH env variable. So both tests should fail obviously.

For fixing that, we have added an extra check to verify if the execution example binaries were successful or not. In case of such executions were not successful, the tests will fail.

This PR fixes the issue https://github.com/MEN-Mikro-Elektronik/mdis_test_system/issues/24